### PR TITLE
Update to allow publishing releases

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,24 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+    authors:
+      - octocat
+  categories:
+    - title: Breaking Changes
+      labels:
+        - Semver-Major
+        - breaking-change
+    - title: Exciting New Features
+      labels:
+        - Semver-Minor
+        - enhancement
+    - title: Bugfixes
+      labels:
+        - bug
+    - title: Dependency Updates
+      labels:
+        - dependencies
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/csound_builds.yml
+++ b/.github/workflows/csound_builds.yml
@@ -2,7 +2,6 @@ name: csound_builds
 
 env:
   VCPKG_BINARY_SOURCES: "clear;x-gha,readwrite"
-  CSOUND_VERSION: 7.0.0
 
 on:
   push:
@@ -13,7 +12,29 @@ on:
     branches:
       - develop
 
+concurrency:
+  group: ${{ github.ref }}
+
 jobs:
+  update_version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.tag.outputs.new_tag }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Update version
+        id: tag
+        uses: anothrNick/github-tag-action@1.36.0
+        env:
+          RELEASE_BRANCHES: develop,main,release
+          PRERELEASE: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DRY_RUN: true
+
   linux_build:
     name: Linux/Ubuntu build (apt-get)
     runs-on: ubuntu-latest
@@ -84,6 +105,9 @@ jobs:
   iOS_build:
     name: Csound for iOS
     runs-on: macos-latest
+    needs: update_version
+    env:
+      CSOUND_VERSION: ${{ needs.update_version.outputs.version }}
     steps:
       - name: Install dependencies
         run: brew install bison flex
@@ -98,6 +122,7 @@ jobs:
         run: |
           chmod +x build_libsndfile.sh
           ./build_libsndfile.sh
+
 
       - name: Build Csound iOS xcframework
         working-directory: iOs
@@ -190,6 +215,9 @@ jobs:
   macos_build_installer:
     name: MacOS build (installer)
     runs-on: macos-latest
+    needs: update_version
+    env:
+      CSOUND_VERSION: ${{ needs.update_version.outputs.version }}
     steps:
       - name: Checkout source code
         uses: actions/checkout@v1
@@ -392,6 +420,9 @@ jobs:
   windows_build:
     name: Windows build (vcpkg)
     runs-on: windows-latest
+    needs: update_version
+    env:
+      CSOUND_VERSION: ${{ needs.update_version.outputs.version }}
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v1
@@ -601,6 +632,9 @@ jobs:
   android-release:
     name: Csound for Android 
     runs-on: macos-latest
+    needs: update_version
+    env:
+      CSOUND_VERSION: ${{ needs.update_version.outputs.version }}
     steps:
       - name: Install dependencies
         run: brew install swig bison flex
@@ -641,3 +675,45 @@ jobs:
           name: CsoundForAndroid-${{env.CSOUND_VERSION}}
           path: Android/csound-android-${{env.CSOUND_VERSION}}
 
+  publish_artifacts:
+    if: ${{ github.ref == 'refs/heads/develop' && contains(github.event.pull_request.labels.*.name, 'release') }}
+    name: Publish Artifacts
+    runs-on: ubuntu-latest
+    needs: [update_version, windows_build, macos_build_installer, iOS_build, android-release]
+    env:
+      CSOUND_VERSION: ${{ needs.update_version.outputs.version }}
+    steps:
+      - name: Download Windows installer
+        uses: actions/download-artifact@v4
+        with:
+          name: Csound_x64-${{env.CSOUND_VERSION}}.${{github.run_number}}-windows-x64-installer
+          path: Csound_x64-${{env.CSOUND_VERSION}}-windows-x64-installer
+
+      - name: Download macOS installer
+        uses: actions/download-artifact@v4      
+        with:
+          name: csound-${{env.CSOUND_VERSION}}-${{github.run_number}}-macosx-beta
+          path: csound-${{env.CSOUND_VERSION}}-macosx-beta
+
+      - name: Download iOS installer
+        uses: actions/download-artifact@v4
+        with:
+          name: Csound-For-iOS-${{env.CSOUND_VERSION}}
+
+      - name: Download Android installer
+        uses: actions/download-artifact@v4
+        with:
+          name: CsoundForAndroid-${{env.CSOUND_VERSION}}
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag_name: ${{ env.CSOUND_VERSION }}
+          generate_release_notes: true
+          make_latest: true
+          files:
+            Csound_x64-${{env.CSOUND_VERSION}}-windows-x64-installer
+            csound-${{env.CSOUND_VERSION}}-macosx-beta
+            Csound-For-iOS-${{env.CSOUND_VERSION}}
+            CsoundForAndroid-${{env.CSOUND_VERSION}}


### PR DESCRIPTION
When merging a release adding the tag `release` will automatically publish the release.
Update #major version